### PR TITLE
Expand URL Schema Support

### DIFF
--- a/src/__tests__/fixtures/ssh-gitmodules.ini
+++ b/src/__tests__/fixtures/ssh-gitmodules.ini
@@ -1,0 +1,3 @@
+[submodule "ports/mdBook"]
+  path = ports/mdBook
+  url = git@github.com:catppuccin/mdBook.git

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -9,6 +9,7 @@ import {
   Submodule,
   updateToLatestCommit,
   updateToLatestTag,
+  getRemoteName,
 } from "../main";
 import { getExecOutput } from "@actions/exec";
 import {
@@ -66,6 +67,37 @@ test("parse GitHub Action inputs with no input submodules", async () => {
   const actual = await parseInputs();
   expect(actual).toEqual(expected);
 });
+
+test.each([
+  ["ssh://user@host.xz:port/path/to/repo.git/", "port/path/to/repo"],
+  ["ssh://user@host.xz/path/to/repo.git/", "path/to/repo"],
+  ["ssh://host.xz:port/path/to/repo.git/", "port/path/to/repo"],
+  ["ssh://host.xz/path/to/repo.git/", "path/to/repo"],
+  ["ssh://user@host.xz/path/to/repo.git/", "path/to/repo"],
+  ["ssh://host.xz/path/to/repo.git/", "path/to/repo"],
+  ["ssh://user@host.xz/~user/path/to/repo.git/", "user/path/to/repo"],
+  ["ssh://host.xz/~user/path/to/repo.git/", "user/path/to/repo"],
+  ["ssh://user@host.xz/~/path/to/repo.git", "path/to/repo"],
+  ["ssh://host.xz/~/path/to/repo.git", "path/to/repo"],
+  ["user@host.xz:/path/to/repo.git/", "path/to/repo"],
+  ["host.xz:/path/to/repo.git/", "path/to/repo"],
+  ["user@host.xz:~user/path/to/repo.git/", "user/path/to/repo"],
+  ["host.xz:~user/path/to/repo.git/", "user/path/to/repo"],
+  ["user@host.xz:path/to/repo.git", "path/to/repo"],
+  ["host.xz:path/to/repo.git", "path/to/repo"],
+  ["rsync://host.xz/path/to/repo.git/", "path/to/repo"],
+  ["git://host.xz/path/to/repo.git/", "path/to/repo"],
+  ["git://host.xz/~user/path/to/repo.git/", "user/path/to/repo"],
+  ["http://host.xz/path/to/repo.git/", "path/to/repo"],
+  ["https://host.xz/path/to/repo.git/", "path/to/repo"],
+  ["/path/to/repo.git/", "path/to/repo"],
+  ["path/to/repo.git/", "path/to/repo"],
+  ["~/path/to/repo.git", "path/to/repo"],
+  ["file:///path/to/repo.git/", "path/to/repo"],
+  ["file://~/path/to/repo.git/", "path/to/repo"],
+])('getRemoteName(%s) -> %s', (url, expected) => {
+  expect(getRemoteName(url)).toBe(expected)
+})
 
 test("extract single submodule from .gitmodules", async () => {
   const input = await readFile("src/__tests__/fixtures/single-gitmodules.ini");

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -11,7 +11,12 @@ import {
   updateToLatestTag,
 } from "../main";
 import { getExecOutput } from "@actions/exec";
-import { mdBookSubmodule, nvimSubmodule, vscodeIconsSubmodule } from "./utils";
+import {
+  mdBookSubmodule,
+  mdBookSubmoduleSSH,
+  nvimSubmodule,
+  vscodeIconsSubmodule
+} from "./utils";
 import { getInput, setOutput } from "@actions/core";
 
 vi.mock("@actions/core", async () => {
@@ -65,6 +70,37 @@ test("parse GitHub Action inputs with no input submodules", async () => {
 test("extract single submodule from .gitmodules", async () => {
   const input = await readFile("src/__tests__/fixtures/single-gitmodules.ini");
   const expected = [mdBookSubmodule()];
+
+  vi.mocked(getExecOutput)
+    .mockReturnValueOnce(
+      Promise.resolve({
+        exitCode: 0,
+        stdout: `\n${expected[0].previousCommitSha}`,
+        stderr: "",
+      })
+    )
+    .mockReturnValueOnce(
+      Promise.resolve({
+        exitCode: 0,
+        stdout: `\n${expected[0].previousTag}`,
+        stderr: "",
+      })
+    )
+    .mockReturnValueOnce(
+      Promise.resolve({
+        exitCode: 0,
+        stdout: `\n${expected[0].previousTag}`,
+        stderr: "",
+      })
+    );
+
+  const actual = await parseGitmodules(input);
+  expect(actual).toEqual(expected);
+});
+
+test("ensure ssh-style git urls can be parsed", async () => {
+  const input = await readFile("src/__tests__/fixtures/ssh-gitmodules.ini");
+  const expected = [mdBookSubmoduleSSH()];
 
   vi.mocked(getExecOutput)
     .mockReturnValueOnce(

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -53,6 +53,15 @@ export const mdBookSubmodule = (
   }).build();
 };
 
+export const mdBookSubmoduleSSH = (
+  url: string = "git@github.com:catppuccin/mdBook.git"
+) => {
+  let mod = mdBookSubmodule();
+  mod.url = url;
+
+  return mod
+}
+
 export const vscodeIconsSubmodule = (
   name: string = "ports/vscode-icons",
   path: string = "ports/vscode-icons",

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,8 +14,8 @@ const gitmodulesSchema = z.record(
   z.string(),
   z.object({
     path: z.string(),
-    url: z.string().url(),
-  })
+    url: z.string().regex(/[A-Za-z][A-Za-z0-9+.-]*/),
+  }),
 );
 
 export type Inputs = {


### PR DESCRIPTION
Previously this action was limited to HTTP-style URLs (e.g. `https://example.com/repo.git`), but Git supports a variety of URL schemas across different protocols, like SSH, a popular alternative method supported by Github. This PR seeks to allow this action to work on URLs in `.gitmodules` with many different URL formats.

This PR is a follow on from #74. It replaces the existing validation that strictly validates HTTP-style URLs with the [same logic](https://github.com/git/git/blob/66b90d9bad8476f6f3d71f5add5cf78809a998ed/url.c#L8-L14) that Git uses to validate URLs.

Additionally, because URLs no longer follow a strict format, the logic used to extract the remote name was changed. Due to URLs now being so varied, it uses a more dynamic, "best guess" method of identifying the remote name. This component has been tested fairly extensively and it passed all preexisting tests, but it's worth calling out as it is a non-trivial logic change.